### PR TITLE
Exception during policy context, should follow policy

### DIFF
--- a/gossip/exception_policy.py
+++ b/gossip/exception_policy.py
@@ -1,3 +1,4 @@
+import sys
 from contextlib import contextmanager
 
 from ._compat import reraise
@@ -8,7 +9,11 @@ class ExceptionPolicy(object):
     @contextmanager
     def context(self):
         ctx = TriggerContext()
-        yield ctx
+        try:
+             yield ctx
+        except:
+            exc_info = sys.exc_info()
+            self.handle_exception(ctx, exc_info)
         self._handle_trigger_end(ctx)
 
     def handle_exception(self, ctx, exc_info):


### PR DESCRIPTION
When an exception is raised by one of the hooks triggered, but there are deferred hooks that will not be satisfied because of this, the reported exception is CannotResolveDependencies, hiding the real failure.

I think the CannotResolveDependencies exception should follow the exception policy. 

(Alternatively, exceptions should be logged somewhere.)